### PR TITLE
fix deprecated warning (RemovedInDjango40Warning).

### DIFF
--- a/demo/intro.py
+++ b/demo/intro.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 from django.http import HttpResponseRedirect
-from django.conf.urls import url
+from django.urls import re_path
 from pydantic import BaseModel, Field
 from django_mini_fastapi import (
     OpenAPI,
@@ -70,7 +70,7 @@ api = OpenAPI(
 )
 
 urlpatterns = [
-    url(r"^$", redirect_to_doc),
+    re_path(r"^$", redirect_to_doc),
     api.as_django_url_pattern(),
 ]
 

--- a/django_mini_fastapi/api.py
+++ b/django_mini_fastapi/api.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Sequence, Type, Union
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 from django.http import Http404, HttpResponseNotAllowed
 
@@ -114,7 +114,7 @@ class OpenAPI(FastAPI):
             self.add_route(self.rapidoc_url, rapi_doc_html, include_in_schema=False)
 
     def as_django_url_pattern(self):
-        return url(
+        return re_path(
             "^{prefix_path}/(?P<route_path>.*)".format(
                 prefix_path=self.root_path.strip("/")
             ),

--- a/django_mini_fastapi/route.py
+++ b/django_mini_fastapi/route.py
@@ -14,7 +14,7 @@ import re
 
 from pydantic import BaseModel, Field
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from .base import Request, Response
 
@@ -31,7 +31,7 @@ class RouteConfig(BaseModel):
 
 class RoutePath(object):
     def __init__(self, route_path: str):
-        route_path = force_text(route_path)
+        route_path = force_str(route_path)
         assert route_path.startswith("/")
 
         self.org_route_path = route_path


### PR DESCRIPTION
fix deprecated warning.

1. replace force_text with force_str.
2. replace url with re_path.